### PR TITLE
Make it actually compile by adding linker option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	cc -Wextra -Wall -g -o ib2slurm ib2slurm.c -I/usr/include/infiniband -libnetdisc
+	cc -Wextra -Wall -g -o ib2slurm ib2slurm.c -I/usr/include/infiniband -libnetdisc -losmcomp
 
 clean:
 	rm -f ib2slurm core.*


### PR DESCRIPTION
The Makefile is missing a linker to libosmcomp.
Small fix to make it compile under SL